### PR TITLE
Updating Travis CI to build and create .deb file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ script:
   - docker exec build bash -c "eval \$(opam env) && mkdir /root/build && cd /root && cp -r agent build/fog05-0.1 && cd build/fog05-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
   - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
-  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t\$(MAKE) FOS_DIR=\$\$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=\$\$(pwd)/debian/fog05/lib/systemd/system/ install\n">> debian/rules'
-  - docker exec build bash -c 'cd /root/build/fog05-0.1/debian && mkdir -p fog05/lib/systemd/system/'
+  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\tmkdir -p \$\$(pwd)/debian/fog05/lib/systemd/system/\n\t\$(MAKE) FOS_DIR=\$\$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=\$\$(pwd)/debian/fog05/lib/systemd/system/ install\n">> debian/rules'
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l ../"
   - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ script:
   - docker exec build bash -c "eval \$(opam env) && mkdir /root/build && cd /root && cp -r agent build/fog05-0.1 && cd build/fog05-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
   - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
-  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t\$(MAKE) LINUX_PLUGIN_DIR=\$\$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=\$\$(pwd)/debian/fog05/lib/systemd/system/ install\n">> debian/rules'
+  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t\$(MAKE) FOS_DIR=\$\$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=\$\$(pwd)/debian/fog05/lib/systemd/system/ install\n">> debian/rules'
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l ../"
   - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,6 @@ script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
   - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
   - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t\$(MAKE) FOS_DIR=\$\$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=\$\$(pwd)/debian/fog05/lib/systemd/system/ install\n">> debian/rules'
+  - docker exec build bash -c 'cd /root/build/fog05-0.1/debian && mkdir -p fog05/lib/systemd/system/'
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l ../"
   - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,3 @@
-# language: c
-# sudo: required
-# before_install:
-#  - sudo apt update -qq
-#  - sudo apt install libev-dev libssl-dev m4 pkg-config rsync unzip -y
-#  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-# install: bash -ex .travis-opam.sh
-# env:
-#     global:
-#     - INTRAVIS="true"
-# #    - DEPOPTS="atdgen ocp-ocamlres conf-libev"
-#     - PINS="fos-agent:. apero-core:https://github.com/atolab/apero-core.git#0.4.6 dynload-sys:https://github.com/atolab/apero-core.git#0.4.6 apero-net:https://github.com/atolab/apero-net.git#0.4.6 apero-time:https://github.com/atolab/apero-time.git#0.4.6 zenoh-proto:https://github.com/atolab/zenoh.git#0.3.0 zenoh-ocaml:https://github.com/atolab/zenoh.git#0.3.0 yaks-common:https://github.com/atolab/yaks-common.git#0.3.0 yaks-ocaml:https://github.com/atolab/yaks-ocaml.git#0.3.0 fos-sdk:https://github.com/eclipse-fog05/sdk-ocaml.git fos-fim-api:https://github.com/eclipse-fog05/api-ocaml.git"
-#     - PACKAGE=fos-agent
-#     matrix:
-#     - OCAML_VERSION=4.09
-
 os: linux
 language: cpp
 services:
@@ -48,6 +32,6 @@ script:
   - docker exec build bash -c "eval \$(opam env) && mkdir /root/build && cd /root && cp -r agent build/fog05-0.1 && cd build/fog05-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
   - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
-  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\tinstall -D -m 0755 _build/default/fos-agent/fos_agent.exe $(pwd)/debian/fog05/etc/fos/agent\n\tinstall -D etc/fos_agent.service $(pwd)/debian/fog05/lib/systemd/system/fos_agent.service\n\tinstall -D etc/fos_agent.target $(pwd)/debian/fog05/lib/systemd/system/fos_agent.target\n\tinstall -D etc/agent.json $(pwd)/debian/fog05/etc/fos/agent.json\n" >> debian/rules'
-  - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l"
+  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t$(MAKE) LINUX_PLUGIN_DIR=$$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=$$(pwd)/debian/fog05/lib/systemd/system/ install">> debian/rules'
+  - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l ../"
   - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,16 @@ before_install:
   # copying repo inside container
   - docker cp ../agent build:/root/
   - docker exec build bash -c "eval \$(opam env) && opam install dune.1.11.4 atdgen.2.0.0 conf-libev ocp-ocamlres -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-core.git -b 0.4.6 --depth 1 && cd apero-core && opam install . --working-dir -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-net.git -b 0.4.6 --depth 1 && cd apero-net && opam install . --working-dir -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-time.git -b 0.4.6 --depth 1 && cd apero-time && opam install . --working-dir -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/zenoh.git -b 0.3.0 --depth 1 && cd zenoh && opam install . --working-dir -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/yaks-common.git -b 0.3.0 --depth 1 && cd yaks-common && opam install . --working-dir -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/yaks-ocaml.git -b 0.3.0 --depth 1 && cd yaks-ocaml && opam install . --working-dir -y"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/sdk-ocaml.git && cd sdk-ocaml && make install"
-  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/api-ocaml.git && cd api-ocaml && make install"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add apero-core https://github.com/atolab/apero-core.git#0.4.6 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add dynload-sys https://github.com/atolab/apero-core.git#0.4.6 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add apero-net https://github.com/atolab/apero-net.git#0.4.6 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add apero-time https://github.com/atolab/apero-time.git#0.4.6 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add zenoh-proto https://github.com/atolab/zenoh.git#0.3.0 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add zenoh-ocaml https://github.com/atolab/zenoh.git#0.3.0 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add yaks-common https://github.com/atolab/yaks-common.git#0.3.0 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add yaks-ocaml https://github.com/atolab/yaks-ocaml.git#0.3.0 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add fos-sdk https://github.com/eclipse-fog05/sdk-ocaml.git -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add fos-fim-api https://github.com/eclipse-fog05/api-ocaml.git  -y"
 script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/agent && make"
     # building a debian package

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ before_install:
   - docker exec build bash -c "eval \$(opam env) && opam pin add zenoh-ocaml https://github.com/atolab/zenoh.git#0.3.0 -y"
   - docker exec build bash -c "eval \$(opam env) && opam pin add yaks-common https://github.com/atolab/yaks-common.git#0.3.0 -y"
   - docker exec build bash -c "eval \$(opam env) && opam pin add yaks-ocaml https://github.com/atolab/yaks-ocaml.git#0.3.0 -y"
-  - docker exec build bash -c "eval \$(opam env) && opam pin add fos-sdk https://github.com/eclipse-fog05/sdk-ocaml.git -y"
-  - docker exec build bash -c "eval \$(opam env) && opam pin add fos-fim-api https://github.com/eclipse-fog05/api-ocaml.git  -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add fos-sdk https://github.com/eclipse-fog05/sdk-ocaml.git#0.1 -y"
+  - docker exec build bash -c "eval \$(opam env) && opam pin add fos-fim-api https://github.com/eclipse-fog05/api-ocaml.git#0.1  -y"
 script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/agent && make"
     # building a debian package
   - docker exec build bash -c "eval \$(opam env) && mkdir /root/build && cd /root && cp -r agent build/fog05-0.1 && cd build/fog05-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
   - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
-  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t$(MAKE) LINUX_PLUGIN_DIR=$$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=$$(pwd)/debian/fog05/lib/systemd/system/ install">> debian/rules'
+  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\t\$(MAKE) LINUX_PLUGIN_DIR=\$\$(pwd)/debian/fog05/etc/fos SYSTEMD_DIR=\$\$(pwd)/debian/fog05/lib/systemd/system/ install\n">> debian/rules'
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l ../"
   - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/api-ocaml.git && cd api-ocaml && make install"
   - docker exec build bash -c "eval \$(opam env) && cd /root/agent && make"
     # building a debian package
-  - docker exec build bash -c "mkdir /root/build && cd /root && cp agent build/fog05-0.1 && cd build/agent && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
+  - docker exec build bash -c "eval \$(opam env) && mkdir /root/build && cd /root && cp -r agent build/fog05-0.1 && cd build/fog05-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
   - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
-  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\tinstall -D -m 0755 _build/default/fos-agent/fos_agent.exe $(pwd)/debian/fog05/etc/fos/agent\n\tinstall -D etc/fos_agent.service $(pwd)/debian/fog05/lib/systemd/system/\n\tinstall -D etc/fos_agent.target $(pwd)/debian/fog05/lib/systemd/system/\n\tinstall -D etc/agent.json $(pwd)/debian/fog05/etc/fos/agent.json\n" >> debian/rules'
+  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\tinstall -D -m 0755 _build/default/fos-agent/fos_agent.exe $(pwd)/debian/fog05/etc/fos/agent\n\tinstall -D etc/fos_agent.service $(pwd)/debian/fog05/lib/systemd/system/fos_agent.service\n\tinstall -D etc/fos_agent.target $(pwd)/debian/fog05/lib/systemd/system/fos_agent.target\n\tinstall -D etc/agent.json $(pwd)/debian/fog05/etc/fos/agent.json\n" >> debian/rules'
   - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l"
   - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,51 @@
-language: c
-sudo: required
+# language: c
+# sudo: required
+# before_install:
+#  - sudo apt update -qq
+#  - sudo apt install libev-dev libssl-dev m4 pkg-config rsync unzip -y
+#  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+# install: bash -ex .travis-opam.sh
+# env:
+#     global:
+#     - INTRAVIS="true"
+# #    - DEPOPTS="atdgen ocp-ocamlres conf-libev"
+#     - PINS="fos-agent:. apero-core:https://github.com/atolab/apero-core.git#0.4.6 dynload-sys:https://github.com/atolab/apero-core.git#0.4.6 apero-net:https://github.com/atolab/apero-net.git#0.4.6 apero-time:https://github.com/atolab/apero-time.git#0.4.6 zenoh-proto:https://github.com/atolab/zenoh.git#0.3.0 zenoh-ocaml:https://github.com/atolab/zenoh.git#0.3.0 yaks-common:https://github.com/atolab/yaks-common.git#0.3.0 yaks-ocaml:https://github.com/atolab/yaks-ocaml.git#0.3.0 fos-sdk:https://github.com/eclipse-fog05/sdk-ocaml.git fos-fim-api:https://github.com/eclipse-fog05/api-ocaml.git"
+#     - PACKAGE=fos-agent
+#     matrix:
+#     - OCAML_VERSION=4.09
+
+os: linux
+language: cpp
+services:
+  - docker
 before_install:
- - sudo apt update -qq
- - sudo apt install libev-dev libssl-dev m4 pkg-config rsync unzip -y
- - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-install: bash -ex .travis-opam.sh
-env:
-    global:
-    - INTRAVIS="true"
-#    - DEPOPTS="atdgen ocp-ocamlres conf-libev"
-    - PINS="fos-agent:. apero-core:https://github.com/atolab/apero-core.git#0.4.6 dynload-sys:https://github.com/atolab/apero-core.git#0.4.6 apero-net:https://github.com/atolab/apero-net.git#0.4.6 apero-time:https://github.com/atolab/apero-time.git#0.4.6 zenoh-proto:https://github.com/atolab/zenoh.git#0.3.0 zenoh-ocaml:https://github.com/atolab/zenoh.git#0.3.0 yaks-common:https://github.com/atolab/yaks-common.git#0.3.0 yaks-ocaml:https://github.com/atolab/yaks-ocaml.git#0.3.0 fos-sdk:https://github.com/eclipse-fog05/sdk-ocaml.git fos-fim-api:https://github.com/eclipse-fog05/api-ocaml.git"
-    - PACKAGE=fos-agent
-    matrix:
-    - OCAML_VERSION=4.09
+  - docker pull debian:10-slim
+  - docker run -it -d --name build debian:10-slim bash
+  - docker exec build apt update
+  # install deps
+  - docker exec build apt install build-essential devscripts lintian dh-make git wget jq libev-dev libssl-dev python3 python3-dev python3-pip m4 pkg-config rsync unzip cmake sudo -y
+  - docker exec build pip3 install pyangbind
+  # install opam
+  - docker exec build wget -O opam https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux
+  - docker exec build install ./opam /usr/local/bin/opam
+  - docker exec build opam init --disable-sandboxing
+  # copying repo inside container
+  - docker cp ../agent build:/root/
+script:
+  - docker exec build bash -c "eval \$(opam env) && opam install dune.1.11.4 atdgen.2.0.0 conf-libev ocp-ocamlres -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-core.git -b 0.4.6 --depth 1 && cd apero-core && opam install . --working-dir -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-net.git -b 0.4.6 --depth 1 && cd apero-net && opam install . --working-dir -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-time.git -b 0.4.6 --depth 1 && cd apero-time && opam install . --working-dir -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/zenoh.git -b 0.3.0 --depth 1 && cd zenoh && opam install . --working-dir -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/yaks-common.git -b 0.3.0 --depth 1 && cd yaks-common && opam install . --working-dir -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/yaks-ocaml.git -b 0.3.0 --depth 1 && cd yaks-ocaml && opam install . --working-dir -y"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/sdk-ocaml.git && cd sdk-ocaml && make install"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/api-ocaml.git && cd api-ocaml && make install"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/agent && make"
+    # building a debian package
+  - docker exec build bash -c "mkdir /root/build && cd /root && cp agent build/fog05-0.1 && cd build/agent && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"
+  - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && make clean"
+  - docker exec build bash -c "eval \$(opam env) && export DEBEMAIL=\"info@adlink-labs.tech\" && export DEBFULLNAME=\"ATO Labs\" && cd /root/build/fog05-0.1 && dh_make -f ../fog05-0.1.tar.gz -s -y"
+  - docker exec build bash -c 'cd /root/build/fog05-0.1 && printf "override_dh_auto_install:\n\tinstall -D -m 0755 _build/default/fos-agent/fos_agent.exe $(pwd)/debian/fog05/etc/fos/agent\n\tinstall -D etc/fos_agent.service $(pwd)/debian/fog05/lib/systemd/system/\n\tinstall -D etc/fos_agent.target $(pwd)/debian/fog05/lib/systemd/system/\n\tinstall -D etc/agent.json $(pwd)/debian/fog05/etc/fos/agent.json\n" >> debian/rules'
+  - docker exec build bash -c "eval \$(opam env) && cd /root/build/fog05-0.1 && debuild --preserve-envvar PATH -us -uc  && ls -l"
+  - docker exec build bash -c "cd /root/build/ && dpkg -I fog05_0.1-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_install:
   - docker exec build opam init --disable-sandboxing
   # copying repo inside container
   - docker cp ../agent build:/root/
-script:
   - docker exec build bash -c "eval \$(opam env) && opam install dune.1.11.4 atdgen.2.0.0 conf-libev ocp-ocamlres -y"
   - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-core.git -b 0.4.6 --depth 1 && cd apero-core && opam install . --working-dir -y"
   - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/apero-net.git -b 0.4.6 --depth 1 && cd apero-net && opam install . --working-dir -y"
@@ -41,6 +40,7 @@ script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/atolab/yaks-ocaml.git -b 0.3.0 --depth 1 && cd yaks-ocaml && opam install . --working-dir -y"
   - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/sdk-ocaml.git && cd sdk-ocaml && make install"
   - docker exec build bash -c "eval \$(opam env) && cd /root/ && git clone https://github.com/eclipse-fog05/api-ocaml.git && cd api-ocaml && make install"
+script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/agent && make"
     # building a debian package
   - docker exec build bash -c "eval \$(opam env) && mkdir /root/build && cd /root && cp -r agent build/fog05-0.1 && cd build/fog05-0.1 && rm -rf .git && make clean && cd .. && tar -czvf fog05-0.1.tar.gz fog05-0.1"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test:
 	echo "Nothing to do"
 
 install:
+	mkdir -p $(FOS_DIR)
 	install -m 0755 _build/default/fos-agent/fos_agent.exe $(FOS_DIR)/agent
 	install etc/fos_agent.service $(SYSTEMD_DIR)
 	install etc/fos_agent.target $(SYSTEMD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ test:
 	echo "Nothing to do"
 
 install:
-	sudo cp _build/default/fos-agent/fos_agent.exe /etc/fos/agent
-	sudo cp etc/fos_agent.service /lib/systemd/system/
-	sudo cp etc/fos_agent.target /lib/systemd/system/
+	install -m 0755 _build/default/fos-agent/fos_agent.exe /etc/fos/agent
+	install etc/fos_agent.service /lib/systemd/system/
+	install etc/fos_agent.target /lib/systemd/system/
 ifeq "$(wildcard $(FOS_CONF_FILE))" ""
-	sudo cp etc/agent.json /etc/fos/agent.json
+	install etc/agent.json /etc/fos/agent.json
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,25 @@
-FOS_CONF_FILE = /etc/fos/agent.json
+
+
+FOS_DIR = /etc/fos
+SYSTEMD_DIR = /lib/systemd/system
+FOS_CONF_FILE = $(FOS_DIR)/agent.json
 
 
 all:
 
-ifeq "$(INTRAVIS)" "true"
-	echo "Nothing to do"
-else
 	dune build
-endif
 
 clean:
-
-ifeq "$(INTRAVIS)" "true"
-	echo "Nothing to do"
-else
 	dune clean
-endif
+
 
 test:
 	echo "Nothing to do"
 
 install:
-	install -m 0755 _build/default/fos-agent/fos_agent.exe /etc/fos/agent
-	install etc/fos_agent.service /lib/systemd/system/
-	install etc/fos_agent.target /lib/systemd/system/
+	install -m 0755 _build/default/fos-agent/fos_agent.exe $(FOS_DIR)/agent
+	install etc/fos_agent.service $(SYSTEMD_DIR)
+	install etc/fos_agent.target $(SYSTEMD_DIR)
 ifeq "$(wildcard $(FOS_CONF_FILE))" ""
-	install etc/agent.json /etc/fos/agent.json
+	install etc/agent.json  $(FOS_DIR)/agent.json
 endif


### PR DESCRIPTION
With this PR travis-ci is now used to build inside a debian container and generate the .deb file for the agent