### PR TITLE
Possibility to pass environment variable at FDU start/run

### DIFF
--- a/fos-agent/evals.ml
+++ b/fos-agent/evals.ml
@@ -802,11 +802,18 @@ open Utils
     Logs.debug (fun m -> m "[eval_heartbeat] - Returning: %s" (FAgentTypes.string_of_eval_result eval_res));
     Lwt.return @@  FAgentTypes.string_of_eval_result eval_res
   (*  *)
-  let eval_run_fdu myuuid instanceid self _ =
-    Logs.debug (fun m -> m "[eval_run_fdu]- ##############");
-    Logs.debug (fun m -> m "[eval_run_fdu]- InstanceID : %s" instanceid);
+    let eval_start_fdu myuuid instanceid self env =
+    Logs.debug (fun m -> m "[eval_start_fdu]- ##############");
+    Logs.debug (fun m -> m "[eval_start_fdu]- InstanceID : %s Env: %s" instanceid env);
     MVar.read self >>= fun state ->
-    let%lwt res = Yaks_connector.Local.Actual.run_fdu_in_node myuuid instanceid state.yaks in
+    let%lwt res = Yaks_connector.Local.Actual.start_fdu_in_node myuuid instanceid env state.yaks in
+    Lwt.return @@  FAgentTypes.string_of_eval_result res
+  (*  *)
+  let eval_run_fdu myuuid instanceid self env =
+    Logs.debug (fun m -> m "[eval_run_fdu]- ##############");
+    Logs.debug (fun m -> m "[eval_start_fdu]- InstanceID : %s Env: %s" instanceid env);
+    MVar.read self >>= fun state ->
+    let%lwt res = Yaks_connector.Local.Actual.run_fdu_in_node myuuid instanceid env state.yaks in
     Lwt.return @@  FAgentTypes.string_of_eval_result res
   (*  *)
   let eval_log_fdu myuuid instanceid self _ =

--- a/fos-agent/listeners.ml
+++ b/fos-agent/listeners.ml
@@ -405,16 +405,19 @@ open Utils
          ( match fdu.status with
            | `UNDEFINE -> Yaks_connector.Global.Actual.remove_node_fdu (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid self.yaks
            | `CONFIGURE ->
+            let start_f = (Evals.eval_start_fdu (Apero.Option.get self.configuration.agent.uuid) fdu.uuid state) in
             let run_f = (Evals.eval_run_fdu (Apero.Option.get self.configuration.agent.uuid) fdu.uuid state) in
             let ls_f = (Evals.eval_ls_fdu (Apero.Option.get self.configuration.agent.uuid) fdu.uuid state) in
             let log_f = (Evals.eval_log_fdu (Apero.Option.get self.configuration.agent.uuid) fdu.uuid state) in
             let file_f = (Evals.eval_file_fdu (Apero.Option.get self.configuration.agent.uuid) fdu.uuid state) in
+            let _ = Yaks_connector.Global.Actual.add_fdu_start_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid start_f self.yaks in
             let _ = Yaks_connector.Global.Actual.add_fdu_run_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid run_f self.yaks in
             let _ = Yaks_connector.Global.Actual.add_fdu_ls_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid ls_f self.yaks in
             let _ = Yaks_connector.Global.Actual.add_fdu_log_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid log_f self.yaks in
             let _ = Yaks_connector.Global.Actual.add_fdu_file_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid file_f self.yaks in
             Yaks_connector.Global.Actual.add_node_fdu (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid fdu self.yaks >>= Lwt.return
            | `CLEAN ->
+            let _ = Yaks_connector.Global.Actual.remove_fdu_start_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid self.yaks in
             let _ = Yaks_connector.Global.Actual.remove_fdu_run_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid self.yaks in
             let _ = Yaks_connector.Global.Actual.remove_fdu_log_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid self.yaks in
             let _ = Yaks_connector.Global.Actual.remove_fdu_ls_eval (Apero.Option.get @@ self.configuration.agent.system) Yaks_connector.default_tenant_id (Apero.Option.get self.configuration.agent.uuid) fdu.fdu_id fdu.uuid self.yaks in


### PR DESCRIPTION
This PR contains the code that implement the possibility to have environment variables as parametes for the FDU.start and FDU.run functions in the API.
Implements #eclipse-fog05/fog05#190